### PR TITLE
CI: Modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/production_deployment.yaml
+++ b/.github/workflows/production_deployment.yaml
@@ -5,15 +5,26 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
           lfs: true
 
       - name: Setup Rust
@@ -41,13 +52,16 @@ jobs:
         run: |
           cd www
           npm ci
-          npm run build
+          PATH="$HOME/.cargo/bin:$PATH" npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: www/dist
 
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@v4
-        with:
-          token: ${{ secrets.GHPAGES_TOKEN }}
-          repository-name: xkpasswd/xkpasswd.github.io
-          branch: gh-pages
-          folder: www/dist
-          clean: true
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/staging_deployment.yaml
+++ b/.github/workflows/staging_deployment.yaml
@@ -41,7 +41,7 @@ jobs:
         run: |
           cd www
           npm ci
-          npm run build
+          PATH="$HOME/.cargo/bin:$PATH" npm run build
 
       - name: Deploy to Netlify
         id: netlify

--- a/.github/workflows/wasm_pack.yml
+++ b/.github/workflows/wasm_pack.yml
@@ -19,13 +19,13 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install wasm-pack
-        run: cargo binstall wasm-pack --version 0.14.0 --no-confirm
+        run: cargo binstall wasm-pack --version 0.14.0 --no-confirm --force
 
       - name: Test on Chrome
-        run: wasm-pack test --headless --chrome --all-features
+        run: PATH="$HOME/.cargo/bin:$PATH" wasm-pack test --headless --chrome --all-features
 
       - name: Test on Firefox
-        run: wasm-pack test --headless --firefox --all-features
+        run: PATH="$HOME/.cargo/bin:$PATH" wasm-pack test --headless --firefox --all-features
 
   build-size:
     name: Build size limit


### PR DESCRIPTION
## Modernize GitHub Actions workflows

### Summary

Modernize CI/CD workflows with improved reliability and updated actions.

### Changes

#### Production deployment
- Migrate from `JamesIves/github-pages-deploy-action` to `actions/deploy-pages@v4`
- Use `actions/upload-pages-artifact@v4`
- Add concurrency control for deployments
- No PAT required — uses built-in `GITHUB_TOKEN`

#### wasm-pack PATH fix
- Add `PATH="$HOME/.cargo/bin:$PATH"` prefix to all commands using `wasm-pack`
- Affects: wasm_pack.yml, staging_deployment.yaml, production_deployment.yaml
- Add `--force` flag to `cargo binstall` for consistent installs

### Setup Required

After merging, configure **Settings → Pages → Build and deployment → Source** to **"GitHub Actions"**.