### PR TITLE
fix(ci): enable Netlify deploy previews for fork PRs

### DIFF
--- a/.github/workflows/staging_build.yaml
+++ b/.github/workflows/staging_build.yaml
@@ -1,4 +1,4 @@
-name: Staging deployment
+name: Build Preview
 
 on: [pull_request]
 

--- a/.github/workflows/staging_deploy.yaml
+++ b/.github/workflows/staging_deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy Preview
 
 on:
   workflow_run:
-    workflows: ["Staging deployment"]
+    workflows: ["Build Preview"]
     types: [completed]
 
 jobs:

--- a/.github/workflows/staging_deploy.yaml
+++ b/.github/workflows/staging_deploy.yaml
@@ -61,7 +61,7 @@ jobs:
         run: |
           npm install -g netlify-cli
           
-          OUTPUT=$(netlify deploy \
+          OUTPUT=$(netlify deploy --no-build \
             --dir=./artifacts \
             --site="$NETLIFY_SITE_ID" \
             --auth="$NETLIFY_AUTH_TOKEN" \

--- a/.github/workflows/staging_deploy.yaml
+++ b/.github/workflows/staging_deploy.yaml
@@ -17,6 +17,14 @@ jobs:
       pull-requests: write
       actions: read
     steps:
+      - name: Checkout config from main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          sparse-checkout: |
+            netlify.toml
+          sparse-checkout-cone-mode: false
+
       - name: Get PR details
         id: pr
         env:

--- a/.github/workflows/staging_deploy.yaml
+++ b/.github/workflows/staging_deploy.yaml
@@ -1,0 +1,109 @@
+name: Deploy Preview
+
+on:
+  workflow_run:
+    workflows: ["Staging deployment"]
+    types: [completed]
+
+jobs:
+  deploy:
+    name: Deploy to Netlify
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const prs = run.pull_requests;
+            
+            if (!prs || prs.length === 0) {
+              core.setFailed("No associated pull request found for this workflow run.");
+              return;
+            }
+            
+            const prNumber = prs[0].number;
+            const prSha = run.head_sha;
+            
+            const { data: prDetails } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            
+            core.setOutput("number", prNumber);
+            core.setOutput("title", prDetails.title);
+            core.setOutput("sha", prSha);
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-build
+          path: ./artifacts
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Deploy to Netlify
+        id: netlify
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+        run: |
+          npm install -g netlify-cli
+          
+          OUTPUT=$(netlify deploy \
+            --dir=./artifacts \
+            --site="$NETLIFY_SITE_ID" \
+            --auth="$NETLIFY_AUTH_TOKEN" \
+            --message="PR #$PR_NUMBER: $PR_TITLE" \
+            --json)
+          
+          DEPLOY_URL=$(echo "$OUTPUT" | jq -r '.deploy_url')
+          echo "deploy_url=$DEPLOY_URL" >> $GITHUB_OUTPUT
+        timeout-minutes: 5
+
+      - name: Comment PR with preview URL
+        uses: actions/github-script@v7
+        env:
+          DEPLOY_URL: ${{ steps.netlify.outputs.deploy_url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_SHA: ${{ steps.pr.outputs.sha }}
+        with:
+          script: |
+            const { DEPLOY_URL, PR_NUMBER, PR_SHA } = process.env;
+            const prNumber = parseInt(PR_NUMBER);
+            const body = `## 🚀 Deploy Preview\n\n**URL:** ${DEPLOY_URL}\n\n_Commit: ${PR_SHA}_`;
+            
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            
+            const botComment = comments.find(c => 
+              c.user.type === 'Bot' && c.body.includes('Deploy Preview')
+            );
+            
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+            }

--- a/.github/workflows/staging_deploy.yaml
+++ b/.github/workflows/staging_deploy.yaml
@@ -58,6 +58,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
+      - name: Sanitize artifacts
+        run: |
+          # Remove potentially malicious Netlify config files from untrusted artifacts
+          rm -f ./artifacts/_redirects ./artifacts/_headers
+          echo "Sanitized artifacts directory"
+
       - name: Deploy to Netlify
         id: netlify
         env:

--- a/.github/workflows/staging_deploy.yaml
+++ b/.github/workflows/staging_deploy.yaml
@@ -54,14 +54,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: preview-build
-          path: ./artifacts
+          path: ${{ runner.temp }}/artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
       - name: Sanitize artifacts
         run: |
           # Remove potentially malicious Netlify config files from untrusted artifacts
-          rm -f ./artifacts/_redirects ./artifacts/_headers
+          rm -f "$RUNNER_TEMP/artifacts/_redirects" "$RUNNER_TEMP/artifacts/_headers"
           echo "Sanitized artifacts directory"
 
       - name: Deploy to Netlify
@@ -75,7 +75,7 @@ jobs:
           npm install -g netlify-cli
           
           OUTPUT=$(netlify deploy --no-build \
-            --dir=./artifacts \
+            --dir="$RUNNER_TEMP/artifacts" \
             --site="$NETLIFY_SITE_ID" \
             --auth="$NETLIFY_AUTH_TOKEN" \
             --message="PR #$PR_NUMBER: $PR_TITLE" \

--- a/.github/workflows/staging_deploy.yaml
+++ b/.github/workflows/staging_deploy.yaml
@@ -9,7 +9,9 @@ jobs:
   deploy:
     name: Deploy to Netlify
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/staging_deploy.yaml
+++ b/.github/workflows/staging_deploy.yaml
@@ -19,29 +19,28 @@ jobs:
     steps:
       - name: Get PR details
         id: pr
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const run = context.payload.workflow_run;
-            const prs = run.pull_requests;
-            
-            if (!prs || prs.length === 0) {
-              core.setFailed("No associated pull request found for this workflow run.");
-              return;
-            }
-            
-            const prNumber = prs[0].number;
-            const prSha = run.head_sha;
-            
-            const { data: prDetails } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber,
-            });
-            
-            core.setOutput("number", prNumber);
-            core.setOutput("title", prDetails.title);
-            core.setOutput("sha", prSha);
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_TARGET_REPO: ${{ github.repository }}
+          # For fork PRs: "owner:branch", for same-repo PRs: "branch"
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
+          PR_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Query PR number and title by branch name
+          PR_DATA=$(gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" --json number,title)
+          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+          
+          echo "number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          echo "title=${PR_TITLE}" >> $GITHUB_OUTPUT
+          echo "sha=${PR_SHA}" >> $GITHUB_OUTPUT
+          
+          echo "Found PR #${PR_NUMBER}: ${PR_TITLE}"
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/staging_deployment.yaml
+++ b/.github/workflows/staging_deployment.yaml
@@ -3,12 +3,11 @@ name: Staging deployment
 on: [pull_request]
 
 jobs:
-  deploy:
-    name: Deploy Preview
+  build:
+    name: Build Preview
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,54 +42,9 @@ jobs:
           npm ci
           npm run build
 
-      - name: Deploy to Netlify
-        id: netlify
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        run: |
-          npm install -g netlify-cli
-          
-          OUTPUT=$(netlify deploy \
-            --dir=www/dist \
-            --site="$NETLIFY_SITE_ID" \
-            --auth="$NETLIFY_AUTH_TOKEN" \
-            --message="PR #${{ github.event.number }}: ${{ github.event.pull_request.title }}" \
-            --json)
-          
-          DEPLOY_URL=$(echo "$OUTPUT" | jq -r '.deploy_url')
-          echo "deploy_url=$DEPLOY_URL" >> $GITHUB_OUTPUT
-        timeout-minutes: 5
-
-      - name: Comment PR with preview URL
-        uses: actions/github-script@v7
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const deployUrl = '${{ steps.netlify.outputs.deploy_url }}';
-            const body = `## 🚀 Deploy Preview\n\n**URL:** ${deployUrl}\n\n_Commit: ${{ github.event.pull_request.head.sha }}_`;
-            
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            
-            const botComment = comments.find(c => 
-              c.user.type === 'Bot' && c.body.includes('Deploy Preview')
-            );
-            
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: body
-              });
-            }
+          name: preview-build
+          path: www/dist
+          retention-days: 1

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 **/*.rs.bk
 
 **/__pycache__/**
+
+**/.envrc
+**/.netlify/**


### PR DESCRIPTION
## Problem

The Deploy Preview CI job was failing for PRs from forks (like #22) due to a 5-minute timeout. 

**Root cause:** GitHub Actions doesn't expose repository secrets to workflows triggered by pull requests from forked repositories. The `netlify-cli` was stuck on "Waiting for authorization..." because `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` were empty.

## Solution

Split the staging deployment into two workflows using the `workflow_run` pattern:

### 1. `staging_deployment.yaml` (Build)
- Triggered by `pull_request` event
- Builds the site (Rust WASM + Node.js)
- Uploads build artifacts
- **No secrets access** (safe for fork PRs)

### 2. `staging_deploy.yaml` (Deploy)
- Triggered by `workflow_run` when build completes
- Downloads artifacts from the build workflow
- Fetches PR details securely via GitHub API
- Deploys to Netlify with secrets access
- Comments on PR with preview URL

## Security

This approach ensures:
- Fork PR code **never runs with secret access**
- PR metadata comes from trusted GitHub API, not artifacts (prevents spoofing)
- Shell variables use env vars to prevent command injection

## Note for Reviewers

> **Why is there no Deploy Preview for this PR?**
>
> The `workflow_run` event requires the workflow file to exist on the default branch to be triggered. Since `staging_deploy.yaml` is new in this PR, the deploy step won't run until after merge.
>
> This is a one-time bootstrapping issue. After merging:
> - All future PRs (including forks like #22) will get deploy previews automatically
> - This PR only contains CI changes, so there's nothing to preview anyway

Fixes the timeout issue in #22.